### PR TITLE
For 16 thread 16 walker job vmcbatch vmc compare "well"

### DIFF
--- a/src/Estimators/EstimatorManagerBase.h
+++ b/src/Estimators/EstimatorManagerBase.h
@@ -167,16 +167,27 @@ public:
 
   /** stop a block
    * @param accept acceptance rate of this block
+   * 
+   */
+  void stopBlockNew(RealType accept);
+
+  
+  /** stop a block
+   * @param accept acceptance rate of this block
    */
   void stopBlock(RealType accept, bool collectall = true);
+
   /** stop a block
    * @param m list of estimator which has been collecting data independently
    */
   void stopBlock(const std::vector<EstimatorManagerBase*>& m);
 
-  /** At end of block collect the scalar estimators for entire rank
+  /** At end of block collect the scalar estimators for the entire rank
+   *   
+   *  Each is currently accumulates on for crowd of 1 or more walkers
+   *  TODO: What is the correct normalization 
    */
-  void collectScalarEstimators(const RefVector<ScalarEstimatorBase>& scalar_estimators);
+  void collectScalarEstimators(const RefVector<ScalarEstimatorBase>& scalar_estimators, const int total_walkers, const RealType block_weight);
 
   /** accumulate the measurements
    * @param W walkers
@@ -280,7 +291,7 @@ private:
   //Data for communication
   std::vector<BufferType*> RemoteData;
   ///collect data and write
-  void collectBlockAverages(int num_threads);
+  void collectBlockAverages();
   ///add header to an std::ostream
   void addHeader(std::ostream& o);
   size_t FieldWidth;

--- a/src/Estimators/EstimatorManagerCrowd.h
+++ b/src/Estimators/EstimatorManagerCrowd.h
@@ -76,7 +76,7 @@ public:
   /** start  a block
    * @param steps number of steps in a block
    */
-  void startBlock(int steps){};
+  void startBlock(int steps){ block_weight_ = 0.0;};
 
   void stopBlock();
 
@@ -94,10 +94,11 @@ public:
     // This seems like it should really be a pset per walker but so far its just used for
     // things that should be a POD argument
     for (int i = 0; i < num_scalar_estimators; ++i)
-      scalar_estimators_[i]->accumulate(global_walkers, walkers, norm);
+      scalar_estimators_[i]->accumulate(global_walkers, walkers, norm);  
   }
 
   RefVector<EstimatorType> get_scalar_estimators() { return convertPtrToRefVector(scalar_estimators_); }
+  RealType get_block_weight() const { return block_weight_; }
 
 protected:
   ///use bitset to handle options
@@ -112,6 +113,7 @@ protected:
   int acceptInd;
   ///total weight accumulated in a block
   RealType block_weight_;
+
   ///file handler to write data
   std::ofstream* Archive;
   ///file handler to write data for debugging

--- a/src/Estimators/tests/test_manager.cpp
+++ b/src/Estimators/tests/test_manager.cpp
@@ -89,7 +89,7 @@ TEST_CASE("EstimatorManagerBase::collectScalarEstimators", "[estimators]")
   est_list[0].get().scalars.resize(4);
 
 
-  em.collectScalarEstimators(est_list);
+  em.collectScalarEstimators(est_list, 3, 5);
 
   // We have three "walkers" two have one sample each of 1.0
   // one has two samples of 1.0, 2,0

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -306,7 +306,7 @@ public:
 
   bool get(std::ostream& os) const;
 
-  RealType get_LocalEnergy() { return LocalEnergy; }
+  RealType get_LocalEnergy() const { return LocalEnergy; }
   
   void setRandomGenerator(RandomGenerator_t* rng);
 


### PR DESCRIPTION
everything except AcceptRatio is being collected and output.  Qualitatively vmc and vmcbatch compare well for equivalent runs. I've been looking at 16 walkers on 16 threads for vmc and 16 walkers on 16 crowds for vmcbatch.  vmcbatch 8 crowds 2 walkers looks fine as well.

In future work I plan to rename EstimatorManagerCrowd something like MultiAccumulator and removing a great deal from it as its mostly not used.  The clones of EstimatorManageBase were far more than is needed at the thread scope.