### PR TITLE
Unified driver return ham flex eval warmup

### DIFF
--- a/src/QMCHamiltonians/CoulombPotentialFactory.cpp
+++ b/src/QMCHamiltonians/CoulombPotentialFactory.cpp
@@ -78,7 +78,7 @@ void HamiltonianFactory::addMPCPotential(xmlNodePtr cur, bool isphysical)
 
 void HamiltonianFactory::addCoulombPotential(xmlNodePtr cur)
 {
-  typedef QMCHamiltonian::FullPrecReal Return_t;
+  typedef QMCHamiltonian::FullPrecRealType Return_t;
   std::string targetInp(targetPtcl->getName());
   std::string sourceInp(targetPtcl->getName());
   std::string title("ElecElec"), pbc("yes");

--- a/src/QMCHamiltonians/QMCHamiltonian.cpp
+++ b/src/QMCHamiltonians/QMCHamiltonian.cpp
@@ -463,7 +463,7 @@ void QMCHamiltonian::finalize_traces()
  *@param P input configuration containing N particles
  *@return the local energy
  */
-QMCHamiltonian::FullPrecReal QMCHamiltonian::evaluate(ParticleSet& P)
+QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluate(ParticleSet& P)
 {
   LocalEnergy = 0.0;
   for (int i = 0; i < H.size(); ++i)
@@ -487,11 +487,10 @@ QMCHamiltonian::FullPrecReal QMCHamiltonian::evaluate(ParticleSet& P)
   return LocalEnergy;
 }
 
-std::vector<QMCHamiltonian::FullPrecReal>
-QMCHamiltonian::flex_evaluate(const RefVector<QMCHamiltonian>& H_list,
-                              const RefVector<ParticleSet>& P_list)
+std::vector<QMCHamiltonian::FullPrecRealType> QMCHamiltonian::flex_evaluate(const RefVector<QMCHamiltonian>& H_list,
+                                                                            const RefVector<ParticleSet>& P_list)
 {
-  std::vector<FullPrecReal> local_energies(H_list.size(),0.0);
+  std::vector<FullPrecRealType> local_energies(H_list.size(), 0.0);
   if (H_list.size() > 1)
   {
     for (int iw = 0; iw < H_list.size(); iw++)
@@ -533,7 +532,7 @@ QMCHamiltonian::flex_evaluate(const RefVector<QMCHamiltonian>& H_list,
       updateKinetic(HC_list[iw], H_list[iw], P_list[iw]);
     }
 
-    for(int iw= 0; iw < H_list.size(); ++iw)
+    for (int iw = 0; iw < H_list.size(); ++iw)
       local_energies[iw] = H_list[iw].get().get_LocalEnergy();
   }
   else if (H_list.size() == 1)
@@ -544,11 +543,11 @@ QMCHamiltonian::flex_evaluate(const RefVector<QMCHamiltonian>& H_list,
   return local_energies;
 }
 
-QMCHamiltonian::FullPrecReal QMCHamiltonian::evaluateValueAndDerivatives(ParticleSet& P,
-                                                                     const opt_variables_type& optvars,
-                                                                     std::vector<ValueType>& dlogpsi,
-                                                                     std::vector<ValueType>& dhpsioverpsi,
-                                                                     bool compute_deriv)
+QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateValueAndDerivatives(ParticleSet& P,
+                                                                             const opt_variables_type& optvars,
+                                                                             std::vector<ValueType>& dlogpsi,
+                                                                             std::vector<ValueType>& dhpsioverpsi,
+                                                                             bool compute_deriv)
 {
   LocalEnergy = KineticEnergy = H[0]->evaluate(P);
   if (compute_deriv)
@@ -560,7 +559,7 @@ QMCHamiltonian::FullPrecReal QMCHamiltonian::evaluateValueAndDerivatives(Particl
   return LocalEnergy;
 }
 
-QMCHamiltonian::FullPrecReal QMCHamiltonian::evaluateVariableEnergy(ParticleSet& P, bool free_nlpp)
+QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateVariableEnergy(ParticleSet& P, bool free_nlpp)
 {
   RealType nlpp = 0.0;
   RealType ke   = H[0]->evaluate(P);
@@ -643,7 +642,7 @@ void QMCHamiltonian::rejectedMove(ParticleSet& P, Walker_t& ThisWalker)
   }
 }
 
-QMCHamiltonian::FullPrecReal QMCHamiltonian::evaluateWithToperator(ParticleSet& P)
+QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateWithToperator(ParticleSet& P)
 {
   LocalEnergy = 0.0;
   for (int i = 0; i < H.size(); ++i)
@@ -663,12 +662,12 @@ QMCHamiltonian::FullPrecReal QMCHamiltonian::evaluateWithToperator(ParticleSet& 
   return LocalEnergy;
 }
 
-QMCHamiltonian::FullPrecReal QMCHamiltonian::evaluateIonDerivs(ParticleSet& P,
-                                                           ParticleSet& ions,
-                                                           TrialWaveFunction& psi,
-                                                           ParticleSet::ParticlePos_t& hf_term,
-                                                           ParticleSet::ParticlePos_t& pulay_terms,
-                                                           ParticleSet::ParticlePos_t& wf_grad)
+QMCHamiltonian::FullPrecRealType QMCHamiltonian::evaluateIonDerivs(ParticleSet& P,
+                                                                   ParticleSet& ions,
+                                                                   TrialWaveFunction& psi,
+                                                                   ParticleSet::ParticlePos_t& hf_term,
+                                                                   ParticleSet::ParticlePos_t& pulay_terms,
+                                                                   ParticleSet::ParticlePos_t& wf_grad)
 {
   ParticleSet::ParticleGradient_t wfgradraw_(ions.getTotalNum());
   wfgradraw_           = 0.0;
@@ -685,9 +684,9 @@ QMCHamiltonian::FullPrecReal QMCHamiltonian::evaluateIonDerivs(ParticleSet& P,
   return localEnergy;
 }
 
-QMCHamiltonian::FullPrecReal QMCHamiltonian::getEnsembleAverage()
+QMCHamiltonian::FullPrecRealType QMCHamiltonian::getEnsembleAverage()
 {
-  FullPrecReal sum = 0.0;
+  FullPrecRealType sum = 0.0;
   for (int i = 0; i < H.size(); i++)
     sum += H[i]->getEnsembleAverage();
   return sum;

--- a/src/QMCHamiltonians/QMCHamiltonian.h
+++ b/src/QMCHamiltonians/QMCHamiltonian.h
@@ -44,7 +44,7 @@ class QMCHamiltonian
 public:
   typedef OperatorBase::RealType RealType;
   typedef OperatorBase::ValueType ValueType;
-  using FullPrecReal = QMCTraits::FullPrecRealType;
+  using FullPrecRealType = QMCTraits::FullPrecRealType;
   typedef OperatorBase::PropertySetType PropertySetType;
   typedef OperatorBase::BufferType BufferType;
   typedef OperatorBase::Walker_t Walker_t;
@@ -169,9 +169,9 @@ public:
   void update_source(ParticleSet& s);
 
   ////return the LocalEnergy \f$=\sum_i H^{qmc}_{i}\f$
-  inline FullPrecReal getLocalEnergy() { return LocalEnergy; }
+  inline FullPrecRealType getLocalEnergy() { return LocalEnergy; }
   ////return the LocalPotential \f$=\sum_i H^{qmc}_{i} - KE\f$
-  inline FullPrecReal getLocalPotential() { return LocalEnergy - KineticEnergy; }
+  inline FullPrecRealType getLocalPotential() { return LocalEnergy - KineticEnergy; }
   void auxHevaluate(ParticleSet& P);
   void auxHevaluate(ParticleSet& P, Walker_t& ThisWalker);
   void auxHevaluate(ParticleSet& P, Walker_t& ThisWalker, bool do_properties, bool do_collectables);
@@ -216,8 +216,8 @@ public:
    *
    * P.R, P.G and P.L are used to evaluate the LocalEnergy.
    */
-  FullPrecReal evaluate(ParticleSet& P);
-  
+  FullPrecRealType evaluate(ParticleSet& P);
+
   /** batched version of evaluate for LocalEnergy 
    *
    *  Encapsulation is ignored for H_list hamiltonians method uses its status as QMCHamiltonian to break encapsulation.
@@ -225,14 +225,14 @@ public:
    *  Bugs could easily be created by accessing this scope.
    *  This should be set to static and fixed.
    */
-  static std::vector<QMCHamiltonian::FullPrecReal>
-  flex_evaluate(const RefVector<QMCHamiltonian>& H_list, const RefVector<ParticleSet>& P_list);
+  static std::vector<QMCHamiltonian::FullPrecRealType> flex_evaluate(const RefVector<QMCHamiltonian>& H_list,
+                                                                     const RefVector<ParticleSet>& P_list);
 
   /** evaluate Local energy with Toperators updated.
    * @param P ParticleSEt
    * @return Local energy
    */
-  FullPrecReal evaluateWithToperator(ParticleSet& P);
+  FullPrecRealType evaluateWithToperator(ParticleSet& P);
 
   /** evaluate energy and derivatives wrt to the variables
    * @param P ParticleSet
@@ -241,11 +241,11 @@ public:
    * @param dhpsioverpsi \f$\partial(\hat{h}\Psi({\bf R})/\Psi({\bf R})) /\partial \alpha \f$
    * @param compute_deriv if true, compute dhpsioverpsi of the non-local potential component
    */
-  FullPrecReal evaluateValueAndDerivatives(ParticleSet& P,
-                                        const opt_variables_type& optvars,
-                                        std::vector<ValueType>& dlogpsi,
-                                        std::vector<ValueType>& dhpsioverpsi,
-                                        bool compute_deriv);
+  FullPrecRealType evaluateValueAndDerivatives(ParticleSet& P,
+                                               const opt_variables_type& optvars,
+                                               std::vector<ValueType>& dlogpsi,
+                                               std::vector<ValueType>& dhpsioverpsi,
+                                               bool compute_deriv);
 
   /** evaluate local energy and derivatives w.r.t ionic coordinates.  
   * @param P target particle set (electrons)
@@ -256,12 +256,12 @@ public:
   * @param wf_grad  Re (dPsi/Psi)
   * @return Local Energy.
   */
-  FullPrecReal evaluateIonDerivs(ParticleSet& P,
-                             ParticleSet& ions,
-                             TrialWaveFunction& psi,
-                             ParticleSet::ParticlePos_t& hf_terms,
-                             ParticleSet::ParticlePos_t& pulay_terms,
-                             ParticleSet::ParticlePos_t& wf_grad);
+  FullPrecRealType evaluateIonDerivs(ParticleSet& P,
+                                     ParticleSet& ions,
+                                     TrialWaveFunction& psi,
+                                     ParticleSet::ParticlePos_t& hf_terms,
+                                     ParticleSet::ParticlePos_t& pulay_terms,
+                                     ParticleSet::ParticlePos_t& wf_grad);
   /** set non local moves options
    * @param cur the xml input
    */
@@ -288,13 +288,13 @@ public:
    * @param free_nlpp if true, non-local PP is a variable
    * @return KE + NonLocal potential
    */
-  FullPrecReal evaluateVariableEnergy(ParticleSet& P, bool free_nlpp);
+  FullPrecRealType evaluateVariableEnergy(ParticleSet& P, bool free_nlpp);
 
   /** return an average value of the LocalEnergy
    *
    * Introduced to get a collective value
    */
-  FullPrecReal getEnsembleAverage();
+  FullPrecRealType getEnsembleAverage();
 
   void resetTargetParticleSet(ParticleSet& P);
 
@@ -310,7 +310,7 @@ public:
   bool get(std::ostream& os) const;
 
   RealType get_LocalEnergy() const { return LocalEnergy; }
-  
+
   void setRandomGenerator(RandomGenerator_t* rng);
 
   /** return a clone */
@@ -338,11 +338,11 @@ private:
   ///starting index
   int numCollectables;
   ///Current Local Energy
-  FullPrecReal LocalEnergy;
+  FullPrecRealType LocalEnergy;
   ///Current Kinetic Energy
-  FullPrecReal KineticEnergy;
+  FullPrecRealType KineticEnergy;
   ///Current Local Energy for the proposed move
-  FullPrecReal NewLocalEnergy;
+  FullPrecRealType NewLocalEnergy;
   ///getName is in the way
   std::string myName;
   ///vector of Hamiltonians


### PR DESCRIPTION
1. The step timer must be invoked per step instead of over all the warm up steps.
2. prefer FullPrecRealType. FullPrecReal doesn't seem to help the consistency.