### PR TITLE
Simpilify resize logic

### DIFF
--- a/src/OhmmsPETE/OhmmsVector.h
+++ b/src/OhmmsPETE/OhmmsVector.h
@@ -103,10 +103,7 @@ public:
   //! Destructor
   virtual ~Vector()
   {
-    if (nAllocated)
-    {
-      mAllocator.deallocate(X, nAllocated);
-    }
+    free();
   }
 
   // Attach to pre-allocated memory
@@ -214,6 +211,7 @@ private:
   ///allocator
   Alloc mAllocator;
 
+  ///a dumb resize, always free existing memory and resize to n. n must be protected positive
   inline void resize_impl(size_t n)
   {
     if (nAllocated)

--- a/src/simd/Mallocator.hpp
+++ b/src/simd/Mallocator.hpp
@@ -43,7 +43,7 @@ struct Mallocator
   T* allocate(std::size_t n)
   {
     if (n == 0)
-      throw std::runtime_error("Mallocator does not accept size 0 allocations.");
+      throw std::runtime_error("Mallocator::allocate does not accept size 0 allocations.");
     void* pt(nullptr);
     std::size_t asize = n * sizeof(T);
     std::size_t amod  = asize % ALIGN;
@@ -69,7 +69,12 @@ struct Mallocator
     return static_cast<T*>(pt);
   }
 
-  void deallocate(T* p, std::size_t) { free(p); }
+  void deallocate(T* p, std::size_t n)
+  {
+    if (n == 0)
+      throw std::runtime_error("Mallocator::deallocate does not accept size 0 allocations.");
+    free(p);
+  }
 };
 
 template<class T1, size_t ALIGN1, class T2, size_t ALIGN2>


### PR DESCRIPTION
1. having both deallocate and free is confusing. I prefer to keep only free() which is consistent with all the ohmms containers.
2. throw error at Mallocator::deallocate as well.