### PR TITLE
Restore spawnCrowdClone() const

### DIFF
--- a/src/Estimators/EnergyDensityEstimator.cpp
+++ b/src/Estimators/EnergyDensityEstimator.cpp
@@ -396,7 +396,7 @@ void NEEnergyDensityEstimator::write(hdf_archive& file)
   file.pop();
 }
 
-std::unique_ptr<OperatorEstBase> NEEnergyDensityEstimator::spawnCrowdClone()
+std::unique_ptr<OperatorEstBase> NEEnergyDensityEstimator::spawnCrowdClone() const
 {
   auto spawn_data_locality = data_locality_;
   auto data_size           = this->data_.size();

--- a/src/Estimators/EnergyDensityEstimator.h
+++ b/src/Estimators/EnergyDensityEstimator.h
@@ -90,7 +90,7 @@ public:
   void packData(PooledData<Real>& buffer) override;
   void unpackData(PooledData<Real>& buffer) override;
 
-  UPtr<OperatorEstBase> spawnCrowdClone() override;
+  UPtr<OperatorEstBase> spawnCrowdClone() const override;
 
   /** start block entry point
    */

--- a/src/Estimators/MagnetizationDensity.cpp
+++ b/src/Estimators/MagnetizationDensity.cpp
@@ -113,7 +113,7 @@ size_t MagnetizationDensity::computeBin(const QMCT::PosType& r, const unsigned i
   return DIM * point + component;
 }
 
-std::unique_ptr<OperatorEstBase> MagnetizationDensity::spawnCrowdClone()
+std::unique_ptr<OperatorEstBase> MagnetizationDensity::spawnCrowdClone() const
 {
   std::size_t data_size    = data_.size();
   auto spawn_data_locality = data_locality_;

--- a/src/Estimators/MagnetizationDensity.h
+++ b/src/Estimators/MagnetizationDensity.h
@@ -71,7 +71,7 @@ public:
   * @return Size of data.
   */
   size_t getFullDataSize() const override;
-  std::unique_ptr<OperatorEstBase> spawnCrowdClone() override;
+  std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override;
   void registerOperatorEstimator(hdf_archive& file) override;
 
   /**

--- a/src/Estimators/MomentumDistribution.cpp
+++ b/src/Estimators/MomentumDistribution.cpp
@@ -176,7 +176,7 @@ MomentumDistribution::MomentumDistribution(const MomentumDistribution& md, DataL
   data_locality_ = dl;
 }
 
-std::unique_ptr<OperatorEstBase> MomentumDistribution::spawnCrowdClone()
+std::unique_ptr<OperatorEstBase> MomentumDistribution::spawnCrowdClone() const
 {
   std::size_t data_size    = data_.size();
   auto spawn_data_locality = data_locality_;

--- a/src/Estimators/MomentumDistribution.h
+++ b/src/Estimators/MomentumDistribution.h
@@ -91,7 +91,7 @@ public:
 
   /** standard interface
    */
-  std::unique_ptr<OperatorEstBase> spawnCrowdClone() override;
+  std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override;
 
   /** accumulate 1 or more walkers of MomentumDistribution samples
    */

--- a/src/Estimators/OneBodyDensityMatrices.cpp
+++ b/src/Estimators/OneBodyDensityMatrices.cpp
@@ -177,7 +177,7 @@ OneBodyDensityMatrices::OneBodyDensityMatrices(const OneBodyDensityMatrices& obd
   data_locality_ = dl;
 }
 
-std::unique_ptr<OperatorEstBase> OneBodyDensityMatrices::spawnCrowdClone()
+std::unique_ptr<OperatorEstBase> OneBodyDensityMatrices::spawnCrowdClone() const
 {
   std::size_t data_size    = data_.size();
   auto spawn_data_locality = data_locality_;

--- a/src/Estimators/OneBodyDensityMatrices.h
+++ b/src/Estimators/OneBodyDensityMatrices.h
@@ -168,7 +168,7 @@ public:
    */
   OneBodyDensityMatrices(const OneBodyDensityMatrices& obdm, DataLocality dl);
 
-  std::unique_ptr<OperatorEstBase> spawnCrowdClone() override;
+  std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override;
 
   void accumulate(const RefVector<MCPWalker>& walkers,
                   const RefVector<ParticleSet>& psets,

--- a/src/Estimators/OperatorEstBase.h
+++ b/src/Estimators/OperatorEstBase.h
@@ -117,7 +117,7 @@ public:
    */
   virtual void registerOperatorEstimator(hdf_archive& file) {}
 
-  virtual std::unique_ptr<OperatorEstBase> spawnCrowdClone() = 0;
+  virtual std::unique_ptr<OperatorEstBase> spawnCrowdClone() const = 0;
 
   /** Write to previously registered observable_helper hdf5 wrapper.
    *

--- a/src/Estimators/PerParticleHamiltonianLogger.cpp
+++ b/src/Estimators/PerParticleHamiltonianLogger.cpp
@@ -84,12 +84,12 @@ PerParticleHamiltonianLogger::Real PerParticleHamiltonianLogger::sumOverAll() co
   return sum;
 }
 
-std::unique_ptr<OperatorEstBase> PerParticleHamiltonianLogger::spawnCrowdClone()
+std::unique_ptr<OperatorEstBase> PerParticleHamiltonianLogger::spawnCrowdClone() const
 {
   std::size_t data_size    = data_.size();
   auto spawn_data_locality = data_locality_;
 
-  auto spawn = std::make_unique<PerParticleHamiltonianLogger>(*this, spawn_data_locality);
+  auto spawn = std::make_unique<PerParticleHamiltonianLogger>(const_cast<PerParticleHamiltonianLogger&>(*this), spawn_data_locality);
   spawn->get_data().resize(data_size, 0.0);
   return spawn;
 }

--- a/src/Estimators/PerParticleHamiltonianLogger.h
+++ b/src/Estimators/PerParticleHamiltonianLogger.h
@@ -40,7 +40,7 @@ public:
                   const RefVector<QMCHamiltonian>& hams,
                   RandomBase<FullPrecRealType>& rng) override;
 
-  UPtr<OperatorEstBase> spawnCrowdClone() override;
+  UPtr<OperatorEstBase> spawnCrowdClone() const override;
   void startBlock(int steps) override;
 
   void registerListeners(QMCHamiltonian& ham_leader) override;
@@ -59,7 +59,7 @@ public:
   int get_block() { return block_; }
 private:
   bool crowd_clone = false;
-  OptionalRef<PerParticleHamiltonianLogger> rank_estimator_;
+  const OptionalRef<PerParticleHamiltonianLogger> rank_estimator_;
   PerParticleHamiltonianLoggerInput input_;
   int rank_;
   CrowdLogValues values_;

--- a/src/Estimators/SelfHealingOverlap.cpp
+++ b/src/Estimators/SelfHealingOverlap.cpp
@@ -41,7 +41,7 @@ SelfHealingOverlap::SelfHealingOverlap(const SelfHealingOverlap& sh, DataLocalit
   data_locality_ = dl;
 }
 
-std::unique_ptr<OperatorEstBase> SelfHealingOverlap::spawnCrowdClone()
+std::unique_ptr<OperatorEstBase> SelfHealingOverlap::spawnCrowdClone() const
 {
   std::size_t data_size    = data_.size();
   auto spawn_data_locality = data_locality_;

--- a/src/Estimators/SelfHealingOverlap.h
+++ b/src/Estimators/SelfHealingOverlap.h
@@ -59,7 +59,7 @@ public:
 
   /** standard interface
    */
-  std::unique_ptr<OperatorEstBase> spawnCrowdClone() override;
+  std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override;
 
   /** accumulate 1 or more walkers of SelfHealingOverlap samples
    */

--- a/src/Estimators/SpinDensityNew.cpp
+++ b/src/Estimators/SpinDensityNew.cpp
@@ -81,7 +81,7 @@ std::vector<int> SpinDensityNew::getSpeciesSize(const SpeciesSet& species)
 
 size_t SpinDensityNew::getFullDataSize() const { return species_.size() * derived_parameters_.npoints; }
 
-std::unique_ptr<OperatorEstBase> SpinDensityNew::spawnCrowdClone()
+std::unique_ptr<OperatorEstBase> SpinDensityNew::spawnCrowdClone() const
 {
   std::size_t data_size    = data_.size();
   auto spawn_data_locality = data_locality_;

--- a/src/Estimators/SpinDensityNew.h
+++ b/src/Estimators/SpinDensityNew.h
@@ -78,7 +78,7 @@ public:
 
   /** standard interface
    */
-  std::unique_ptr<OperatorEstBase> spawnCrowdClone() override;
+  std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override;
 
   /** accumulate 1 or more walkers of SpinDensity samples
    */

--- a/src/Estimators/tests/FakeOperatorEstimator.h
+++ b/src/Estimators/tests/FakeOperatorEstimator.h
@@ -40,7 +40,7 @@ public:
 
   void startBlock(int nsteps) override {}
 
-  std::unique_ptr<OperatorEstBase> spawnCrowdClone() override
+  std::unique_ptr<OperatorEstBase> spawnCrowdClone() const override
   {
     return std::make_unique<FakeOperatorEstimator>(*this);
   }


### PR DESCRIPTION
## Proposed changes
PerParticleHamiltonianLogger has its own I/O logic and it breaks the constness of spawnCrowdClone. Let us leave that internal to the class rather than polluting the API.

## What type(s) of changes does this code introduce?
- Refactoring (no functional changes, no api changes)

### Does this introduce a breaking change?
- No

## What systems has this change been tested on?
laptop

## Checklist
- Yes. This PR is up to date with current the current state of 'develop'
